### PR TITLE
VVJSONSchemaValidation-tvOS.xcscheme: update BuildableName.

### DIFF
--- a/VVJSONSchemaValidation.xcodeproj/xcshareddata/xcschemes/VVJSONSchemaValidation-tvOS.xcscheme
+++ b/VVJSONSchemaValidation.xcodeproj/xcshareddata/xcschemes/VVJSONSchemaValidation-tvOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "7D8EDAB61D3F9582005557ED"
-               BuildableName = "VVJSONSchemaValidation-tvOS.framework"
+               BuildableName = "VVJSONSchemaValidation.framework"
                BlueprintName = "VVJSONSchemaValidation-tvOS"
                ReferencedContainer = "container:VVJSONSchemaValidation.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7D8EDAB61D3F9582005557ED"
-            BuildableName = "VVJSONSchemaValidation-tvOS.framework"
+            BuildableName = "VVJSONSchemaValidation.framework"
             BlueprintName = "VVJSONSchemaValidation-tvOS"
             ReferencedContainer = "container:VVJSONSchemaValidation.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7D8EDAB61D3F9582005557ED"
-            BuildableName = "VVJSONSchemaValidation-tvOS.framework"
+            BuildableName = "VVJSONSchemaValidation.framework"
             BlueprintName = "VVJSONSchemaValidation-tvOS"
             ReferencedContainer = "container:VVJSONSchemaValidation.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
`BuildableName` should be`VVJSONSchemaValidation.framework`.
This would always change in Facetune, now it will be permanent.
Though unused by us - it would make the status unclean.

@StatusReport 
